### PR TITLE
Expand OTP responses path list

### DIFF
--- a/example-config.yml
+++ b/example-config.yml
@@ -79,4 +79,3 @@ irrelevant_destinations:
 previous_trips:
   path: previously_requested_trips.csv
   od_column: od_code
-  

--- a/example-config.yml
+++ b/example-config.yml
@@ -79,3 +79,4 @@ irrelevant_destinations:
 previous_trips:
   path: previously_requested_trips.csv
   od_column: od_code
+

--- a/scripts/cost_metrics_from_responses.py
+++ b/scripts/cost_metrics_from_responses.py
@@ -34,20 +34,26 @@ from otp4gb.cost import cost_matrix_from_responses, AggregationMethod
 # CONSTANTS
 # response paths should be a pathlib.Path object
 RESPONSES_PATHS = [
-    Path(r"E:\OTP_Processing\OTP outputs\TRSE OTP Related runs\First OTP run (signalis)\BUS_WALK_costs_20230608T0900.csv-response_data.jsonl"),
-    Path(r"E:\OTP_Processing\OTP outputs\TNE_bus_test\costs\AM\BUS_WALK_costs_20230608T0900.csv-response_data.jsonl"),
+    Path(
+        r"E:\OTP_Processing\OTP outputs\TRSE OTP Related runs\First OTP run (signalis)\BUS_WALK_costs_20230608T0900.csv-response_data.jsonl"
+    ),
+    Path(
+        r"E:\OTP_Processing\OTP outputs\TNE_bus_test\costs\AM\BUS_WALK_costs_20230608T0900.csv-response_data.jsonl"
+    ),
 ]
 # Output path for the compiled responses matrix
 MATRIX_PATH = Path(r"C:\Users\Signalis\Desktop\temp_outputs\test_output_matrix.csv")
 
 # SCRIPT
-print("Script commenced: {}\nCompiling responses {}".format(
-    datetime.now().strftime("%H:%M:%S"),
-    RESPONSES_PATHS,
-))
+print(
+    "Script commenced: {}\nCompiling responses {}".format(
+        datetime.now().strftime("%H:%M:%S"),
+        RESPONSES_PATHS,
+    )
+)
 
-cost_matrix_from_responses(responses_files=RESPONSES_PATHS,
-                           matrix_file=MATRIX_PATH,
-                           aggregation_method=AggregationMethod)
+cost_matrix_from_responses(
+    *RESPONSES_PATHS, matrix_file=MATRIX_PATH, aggregation_method=AggregationMethod
+)
 
 print("Script finished: {}".format(datetime.now().strftime("%H:%M:%S")))


### PR DESCRIPTION
Change cost_matrics_from_responses.py functionality to accept list of pathlib Paths to OTP responses.

Had intended to add this after merging V2 into main but did not realise main is protected. 

From https://github.com/Transport-for-the-North/otp4gb-py/pull/4#issuecomment-1628702229