### PR TITLE
Add bin and asset dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # general dumping ground for stuff
 scratch/
 
+# bin directory
+bin/
+
+# assets directory
+assets/
+
 # Working directory for building zip files
 zip_tmp/
 


### PR DESCRIPTION
Adds the bin and assets directories to .gitignore

Should help clear up the changes files tracker when working on updates. 

The bin & assets dir should always be empty when the repo is cloned. These directories are populated with setup.py (bin), and by the user (assets)

If this is not a useful edit I can remove - thoughts appreciated