### PR TITLE
Feat: server prepare functionality

### DIFF
--- a/otp4gb/__main__.py
+++ b/otp4gb/__main__.py
@@ -52,22 +52,10 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="date for routing graph preparation",
     )
     process_parser.add_argument(
-        "-F",
-        "--force",
-        action="store_true",
-        help="force recreation of the OTP graph file",
-    )
-    process_parser.add_argument(
         "-s",
         "--save_parameters",
         action="store_true",
         help="save build parameters to JSON lines files and exit",
-    )
-    process_parser.add_argument(
-        "-p",
-        "--prepare",
-        action="store_true",
-        help="prepare the OTP graph and GTFS files without running routing analysis",
     )
 
     server_parser = subparsers.add_parser(
@@ -84,6 +72,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
             "folder",
             type=pathlib.Path,
             help="folder containing config file and OTP graphs",
+        )
+        p.add_argument(
+            "-p",
+            "--prepare",
+            action="store_true",
+            help="prepare the OTP graph and GTFS files without running routing analysis",
+        )
+        p.add_argument(
+            "-F",
+            "--force",
+            action="store_true",
+            help="force recreation of the OTP graph file",
         )
 
     process_parser.set_defaults(func=otp.run_process)

--- a/otp4gb/config.py
+++ b/otp4gb/config.py
@@ -40,6 +40,22 @@ class TimePeriod(pydantic.BaseModel):  # pylint: disable=no-member
     search_window_minutes: Optional[int] = None
 
 
+class PrepareConfig(ctk.BaseConfig):
+    """Parse the YAML config file for preparing graph only."""
+
+    osm_file: str
+    date: datetime.date
+    gtfs_files: Optional[list[str]] = None
+    extents: Optional[Bounds] = None
+
+    # Makes a classmethod not recognised by pylint, hence disabling self check
+    @pydantic.validator("extents", pre=True)
+    def _extents(cls, value):  # pylint: disable=no-self-argument
+        if not isinstance(value, dict):
+            return value
+        return Bounds.from_dict(value)
+
+
 class ProcessConfig(ctk.BaseConfig):
     """Class for managing (and parsing) the YAML config file."""
 
@@ -77,6 +93,16 @@ class ProcessConfig(ctk.BaseConfig):
             return None
 
         return value
+
+    @property
+    def prepare_parameters(self) -> PrepareConfig:
+        """Parameters for preparing the OTP graph."""
+        return PrepareConfig(
+            osm_file=self.osm_file,
+            gtfs_files=self.gtfs_files,
+            date=self.date,
+            extents=self.extents,
+        )
 
 
 def load_config(folder: pathlib.Path) -> ProcessConfig:

--- a/otp4gb/osmconvert.py
+++ b/otp4gb/osmconvert.py
@@ -1,8 +1,9 @@
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
-from typing import Optional
+from typing import Literal, Optional
 
 from otp4gb.centroids import Bounds
 from otp4gb.config import BIN_DIR, ROOT_DIR
@@ -34,7 +35,25 @@ def _command(input_, bounds, output):
     return command + args
 
 
-def osm_convert(input_, output, extents: Optional[Bounds] = None):
+def _osm_type(path: pathlib.Path) -> Literal["osm.xml", "pbf"]:
+    """Basic check if the OSM is XML or binary (pbf) format."""
+    with open(path, mode="rb") as file:
+        header = file.read(50)
+
+    try:
+        text = header.decode("utf-8")
+    except UnicodeDecodeError:
+        return "pbf"
+
+    if text.startswith("<?xml version='1.0' encoding='UTF-8'?>"):
+        return "osm.xml"
+    return "pbf"
+
+
+def osm_convert(
+    input_: pathlib.Path, output: pathlib.Path, extents: Optional[Bounds] = None
+):
+    output = output.with_suffix("." + _osm_type(input_))
     if extents is None:
         LOG.info("Copying OSM file '%s' to '%s' without filtering", input_, output)
         shutil.copy(input_, output)

--- a/otp4gb/otp.py
+++ b/otp4gb/otp.py
@@ -99,7 +99,7 @@ class Server:
         )
         atexit.register(self.stop)
         self._check_server()
-        LOG.info("OTP server started")
+        LOG.info("OTP server started at localhost:%s", self.port)
 
     def end_java_subprocess(self):
         check_name = "java.exe"
@@ -235,7 +235,7 @@ def run_server(*, folder: pathlib.Path, prepare: bool, force: bool, **_) -> None
 
         params = config.PrepareConfig.load_yaml(config_path)
         LOG.info("Loaded config from %s\n%s", config_path, params.to_yaml())
-        folder = _prepare(folder, params, force)
+        _prepare(folder, params, force)
 
     server = Server(folder)
     server.start()

--- a/otp4gb/otp.py
+++ b/otp4gb/otp.py
@@ -64,7 +64,6 @@ def prepare_graph(build_dir: pathlib.Path) -> None:
 
 
 class Server:
-
     def __init__(self, base_dir, port=8080):
         self.base_dir = base_dir
         self.port = int(port)
@@ -221,12 +220,22 @@ class Server:
         LOG.info("OTP server stopped")
 
 
-def run_server(*, folder: pathlib.Path, **_) -> None:
+def run_server(*, folder: pathlib.Path, prepare: bool, force: bool, **_) -> None:
     """Run OTP server at given `folder`."""
     LOG.info("Running OTP4GB server")
 
     if not folder.is_dir():
         raise NotADirectoryError(folder)
+
+    if prepare:
+        LOG.info("Preparing OTP graph")
+        config_path = pathlib.Path(folder) / "config.yml"
+        if not config_path.is_file():
+            raise FileNotFoundError("config required for preparing")
+
+        params = config.PrepareConfig.load_yaml(config_path)
+        LOG.info("Loaded config from %s\n%s", config_path, params.to_yaml())
+        folder = _prepare(folder, params, force)
 
     server = Server(folder)
     server.start()
@@ -236,7 +245,9 @@ def run_server(*, folder: pathlib.Path, **_) -> None:
     server.stop()
 
 
-def _prepare(folder: pathlib.Path, params: config.ProcessConfig, force: bool) -> None:
+def _prepare(
+    folder: pathlib.Path, params: config.PrepareConfig, force: bool
+) -> pathlib.Path:
     LOG.info("Running OTP4GB prepare")
 
     graph_file = folder / GRAPH_FILE_SUBPATH
@@ -265,14 +276,17 @@ def _prepare(folder: pathlib.Path, params: config.ProcessConfig, force: bool) ->
 
     graph_file.parent.mkdir(parents=True)
 
-    date_filter_string = "{}:{}".format(params.date, params.date + dt.timedelta(days=1))
-    LOG.debug("date_filter_string is %s", date_filter_string)
-    gtfs_filter.filter_gtfs_files(
-        params.gtfs_files,
-        output_dir=graph_file.parent,
-        date=date_filter_string,
-        extents=params.extents,
-    )
+    if params.gtfs_files is not None:
+        date_filter_string = "{}:{}".format(
+            params.date, params.date + dt.timedelta(days=1)
+        )
+        LOG.debug("date_filter_string is %s", date_filter_string)
+        gtfs_filter.filter_gtfs_files(
+            params.gtfs_files,
+            output_dir=graph_file.parent,
+            date=date_filter_string,
+            extents=params.extents,
+        )
 
     # Crop the osm.pbf map of GB to the bounding box
     osmconvert.osm_convert(
@@ -285,6 +299,7 @@ def _prepare(folder: pathlib.Path, params: config.ProcessConfig, force: bool) ->
     shutil.copy(config.CONF_DIR / "router-config.json", graph_file.parent)
 
     prepare_graph(graph_file.parent)
+    return graph_file.parent
 
 
 def _process(folder: pathlib.Path, save_parameters: bool, params: config.ProcessConfig):
@@ -432,7 +447,7 @@ def run_process(
         params.extents = custom_bounds[bounds]
 
     if prepare or force or not (folder / GRAPH_FILE_SUBPATH).is_file():
-        _prepare(folder, params, force)
+        _prepare(folder, params.prepare_parameters, force)
 
     if prepare:
         LOG.info(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ BINARY_FOLDER = pathlib.Path("bin")
 OSM_NAME = "osmconvert64.exe"
 OSMCONVERT_DOWNLOAD_URL = "https://yadi.sk/d/Vnwc4kut3LCBFm"
 # TODO(MB) Find the most up to date version of maven by checking https://dlcdn.apache.org/maven/maven-3
-MAVEN_VERSION = "3.8.8"
+MAVEN_VERSION = "3.8.9"
 MAVEN_PATH = BINARY_FOLDER / f"apache-maven-{MAVEN_VERSION}/bin/mvn"
 MAVEN_DOWNLOAD_URL = (
     f"https://dlcdn.apache.org/maven/maven-3/{MAVEN_VERSION}/"


### PR DESCRIPTION
# Changes

Added functionality to prepare graph before running the server to enable setting up an OTP server from scratch without running process. Made GTFS files optional for server prepare.
Checked format of OSM files (xml or binary).
Switched to maven v3.8.9, because v3.8.8 is no longer available

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases) - No
- [ ] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - NA
- [ ] Code linting, tests and other workflows pass
